### PR TITLE
Fix failed test warning

### DIFF
--- a/makehelp.sh
+++ b/makehelp.sh
@@ -96,7 +96,7 @@ parse_makefile ()
             declare -a buf
         fi
     done
-    if (( "${_INJECT_MAKEHELP:-}" == 0 )); then
+    if (( "${_INJECT_MAKEHELP:-1}" == 0 )); then
         # dirty hack time!
         # if --static, there *should* be no makehelp target defined.
         # let's inject it now...


### PR DESCRIPTION
As reported in issue #4, an empty default value is causing a test
failure to be logged when running without --static.