### PR TITLE
Reenable "osx" platform for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: bash
 
 os:
   - linux
+  - osx
 
 script:
-  - bats tests/ 
+  - make test 

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,13 @@ contrib:
 	mkdir -p $@
 
 contrib/bats: | contrib
-	cd contrib && git clone https://github.com/bats-core/bats-core bats
+	if [ -x "$$(which bats)" ]; then \
+		touch "$@"; \
+	else \
+		cd contrib && git clone --depth=1 https://github.com/bats-core/bats-core bats; \
+	fi
 
 .PHONY: test
 test: PATH:=contrib/bats/bin:$(PATH)
 test: contrib/bats
-	bats tests/
+	export PATH=$(PATH) && bats tests/


### PR DESCRIPTION
- Changed Makefile to use local **bats** if installed and ensure ``PATH`` variable is correctly set.
- Re-added ``osx`` to Travis **os** list.